### PR TITLE
2-gradient beta model uses wrong parameter for second gradient

### DIFF
--- a/R/response-functions.R
+++ b/R/response-functions.R
@@ -188,7 +188,7 @@
 
         ## constant d Eqn 7 in Minchin 1987
         d <- (bx^px[["alpha"]] * (1 - bx)^px[["gamma"]]) *
-            (by^py[["alpha"]] * (1 - by)^px[["gamma"]])
+            (by^py[["alpha"]] * (1 - by)^py[["gamma"]])
 
         ## Using gradfun() compute the part of eqn to the right of the Pi for
         ## gradient x...


### PR DESCRIPTION
The second gradient (y) of 2-gradient beta response model uses
the gamma of the first gradient (x) when adjusting the response height.