### PR TITLE
Add new zero-inflated distributions, change parametrization

### DIFF
--- a/R/coenocline.R
+++ b/R/coenocline.R
@@ -17,8 +17,10 @@
 ##'   \item Negative binomial,
 ##'   \item Bernoulli,
 ##'   \item Beta-Binomial,
-##'   \item Zero-inflated Poisson, and
-##'   \item Zero-inflated Negative binomial
+##'   \item Zero-inflated Poisson, 
+##'   \item Zero-inflated Negative binomial,
+##'   \item Zero-inflated Binomial, and
+##'   \item Zero-inflated Beta-Binomial
 ##' }
 ##'
 ##' Some distributions may need additional parameters beyond the expectation; an example is the \eqn{\alpha}{alpha} parameter of (one parameterisation of) the negative binomial distribution. These parameters are specied via the list \code{countParams}.
@@ -168,18 +170,18 @@
 ##'                 countModel = "poisson", expectation = TRUE)
 ##' plot(y, type = "l", lty = "solid")
 ##'
-##' ## Zero-inflated Poisson, constant gamma
-##' ## =====================================
+##' ## Zero-inflated Poisson, constant zero-inflation
+##' ## ==============================================
 ##'
 ##' y <- coenocline(x, responseModel = "beta", params = params,
-##'                 countModel = "ZIP", countParams = list(gamma = 0))
+##'                 countModel = "ZIP", countParams = list(zprobs = 0.2))
 ##' plot(y, type = "l", lty = "solid")
 ##'
-##' ## Zero-inflated Negative binomial, constant gamma
+##' ## Zero-inflated Negative binomial, constant zero-inflation
 ##' y <- coenocline(x, responseModel = "beta",
 ##'                 params = params,
 ##'                 countModel = "ZINB",
-##'                 countParams = list(alpha = 0.75, gamma = 0))
+##'                 countParams = list(alpha = 0.75, zprobs = 0.2))
 ##' plot(y, type = "l", lty = "solid")
 ##'
 ##' ## Binomial counts, constant size (m) of 100
@@ -208,7 +210,8 @@
                          params,
                          extraParams = NULL,
                          countModel = c("poisson", "negbin", "bernoulli", "binary",
-                                        "binomial", "betabinomial", "ZIP", "ZINB"),
+                                        "binomial", "betabinomial", "ZIP", "ZINB",
+                                         "ZIB", "ZIBB"),
                          countParams = NULL,
                          expectation = FALSE) {
     responseModel <- rModel <- match.arg(responseModel)
@@ -224,7 +227,9 @@
                          binomial = Binomial,
                          betabinomial = BetaBinomial,
                          ZIP = ZIP,
-                         ZINB = ZINB)
+                         ZINB = ZINB,
+                         ZIB = ZIB,
+                         ZIBB = ZIBB)
 
     ## x needs to be a vector, or for bivariate;
     ##   a list of 2 vectors, or a matrix of 2 columns

--- a/R/coenocliner.R
+++ b/R/coenocliner.R
@@ -18,6 +18,8 @@
 ##'   \item Beta-Binomial
 ##'   \item Zero-inflated Poisson (ZIP)
 ##'   \item Zero-inflated Negative Binomial (ZINB)
+##'   \item Zero-inflated Binomial (ZIB)
+##'   \item Zero-inflated Beta-Binomial (ZIBB)
 ##' }
 ##' from which random draws are made.
 ##'

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1,5 +1,8 @@
 ##' @title Wrappers to random number generators for use with coenocliner
 ##'
+##' @references Bolker, B.M. (2008) \emph{Ecological Models and Data
+##' in R.} Princeton University Press.
+##' 
 ##' @param n the number of random draws, equal to number of species times the number of gradient locations.
 ##' @param mu the mean or expectation of the distribution. For \code{Bernoulli}, \code{Binomial}, and \code{BetaBinomial()} this is the probability of occurrence as given by the response function.
 ##' @param alpha numeric; parameter for the negative binomial distribution.
@@ -43,7 +46,10 @@
 
 ##' @rdname distributions
 ##'
-##' @param theta numeric; a positive overdispersion parameter for the Beta-Binomial distribution.
+##' @param theta numeric; a positive inverse overdispersion parameter
+##' for the Beta-Binomial distribution. Low values give high
+##' overdispersion. The variance is
+##' \code{size*mu*(1-mu)*(1+(size-1)/(theta+1))} (Bolker, 2008)
 ##'
 ##' @importFrom stats rbeta rbinom
 `BetaBinomial` <- function(n, mu, size, theta) {

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -57,24 +57,20 @@
 
 ##' @rdname distributions
 ##'
-##' @param gamma numeric; zero-inflation parameter. Leads to the probability of a zero, \eqn{\pi}{pi}, in the binomial part of the ZIP via \eqn{\pi = e^\gamma / (1 + e^\gamma)}{pi = e^gamma / (1 + e^gamma)}. Setting \code{gamma = 0} gives a probability of zero from the binomial part of \eqn{\pi = 0.5}{pi = 0.5}.
-##' @importFrom stats rbinom rpois plogis
-`ZIP` <- function(n, mu, gamma) {
-    pi <- plogis(gamma)
-    pres <- rbinom(n, size = 1, prob = pi)
-    rand <- ifelse(pres > 0, rpois(n, lambda = mu), 0)
-    rand
+##' @param zprobs numeric; zero-inflation parameter giving the
+##' proportion of extraneous zeros. Must be in range
+##' \eqn{0 \dots 1}{0 to 1}.
+##' @importFrom stats runif rpois
+`ZIP` <- function(n, mu, zprobs) {
+    ifelse(runif(n) > zprobs, rpois(n, lambda = mu), 0)
 }
 
 ##' @rdname distributions
 ##'
-##' @importFrom stats rpois rgamma rbinom plogis
-`ZINB` <- function(n, mu, alpha, gamma) {
-    pi <- plogis(gamma)
-    pres <- rbinom(n, size = 1, prob = pi)
-    rand <- ifelse(pres > 0,
-                   rpois(n, lambda = mu * rgamma(n, shape = alpha,
-                            rate = 1/alpha)),
-                   0)
-    rand
+##' @importFrom stats rpois rgamma runif
+`ZINB` <- function(n, mu, alpha, zprobs) {
+    ifelse(runif(n) > zprobs,
+           rpois(n, lambda = mu * rgamma(n, shape = alpha,
+                    rate = 1/alpha)),
+           0)
 }

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -74,3 +74,23 @@
                     rate = 1/alpha)),
            0)
 }
+
+#' @rdname distributions
+#'
+#' @importFrom stats rbinom runif
+# Zero-inflated Binomial
+`ZIB` <- function(n, mu, size, zprobs) {
+    ifelse(runif(n) > zprobs,
+           rbinom(n, size = size, prob = mu),
+           0)
+}
+
+#' @rdname distributions
+#'
+#' @importFrom stats runif
+# Zero-inflated Beta-Binomial
+`ZIBB` <- function(n, mu, size, theta, zprobs) {
+    ifelse(runif(n) > zprobs,
+           BetaBinomial(n, mu = mu, size = size, theta = theta),
+           0)
+}

--- a/man/coenocline.Rd
+++ b/man/coenocline.Rd
@@ -7,8 +7,8 @@ gradients}
 \usage{
 coenocline(x, responseModel = c("gaussian", "beta"), params,
   extraParams = NULL, countModel = c("poisson", "negbin", "bernoulli",
-  "binary", "binomial", "betabinomial", "ZIP", "ZINB"), countParams = NULL,
-  expectation = FALSE)
+  "binary", "binomial", "betabinomial", "ZIP", "ZINB", "ZIB", "ZIBB"),
+  countParams = NULL, expectation = FALSE)
 }
 \arguments{
 \item{x}{one of a numeric vector, a list with two components, each a numeric vector, or a matrix with two columns. The vectors are the locations along the gradient(s) at which species responses are to be simulated.}
@@ -55,8 +55,10 @@ The species response model defines the mean of expected response. (In the case o
   \item Negative binomial,
   \item Bernoulli,
   \item Beta-Binomial,
-  \item Zero-inflated Poisson, and
-  \item Zero-inflated Negative binomial
+  \item Zero-inflated Poisson,
+  \item Zero-inflated Negative binomial,
+  \item Zero-inflated Binomial, and
+  \item Zero-inflated Beta-Binomial
 }
 
 Some distributions may need additional parameters beyond the expectation; an example is the \eqn{\alpha}{alpha} parameter of (one parameterisation of) the negative binomial distribution. These parameters are specied via the list \code{countParams}.
@@ -180,18 +182,18 @@ y <- coenocline(x, responseModel = "beta",
                 countModel = "poisson", expectation = TRUE)
 plot(y, type = "l", lty = "solid")
 
-## Zero-inflated Poisson, constant gamma
-## =====================================
+## Zero-inflated Poisson, constant zero-inflation
+## ==============================================
 
 y <- coenocline(x, responseModel = "beta", params = params,
-                countModel = "ZIP", countParams = list(gamma = 0))
+                countModel = "ZIP", countParams = list(zprobs = 0.2))
 plot(y, type = "l", lty = "solid")
 
-## Zero-inflated Negative binomial, constant gamma
+## Zero-inflated Negative binomial, constant zero-inflation
 y <- coenocline(x, responseModel = "beta",
                 params = params,
                 countModel = "ZINB",
-                countParams = list(alpha = 0.75, gamma = 0))
+                countParams = list(alpha = 0.75, zprobs = 0.2))
 plot(y, type = "l", lty = "solid")
 
 ## Binomial counts, constant size (m) of 100

--- a/man/coenocliner.Rd
+++ b/man/coenocliner.Rd
@@ -25,6 +25,8 @@ and random count or occurrence data can be simulated from suitably parameterised
   \item Beta-Binomial
   \item Zero-inflated Poisson (ZIP)
   \item Zero-inflated Negative Binomial (ZINB)
+  \item Zero-inflated Binomial (ZIB)
+  \item Zero-inflated Beta-Binomial (ZIBB)
 }
 from which random draws are made.
 }

--- a/man/distributions.Rd
+++ b/man/distributions.Rd
@@ -21,9 +21,9 @@ Binomial(n, mu, size)
 
 BetaBinomial(n, mu, size, theta)
 
-ZIP(n, mu, gamma)
+ZIP(n, mu, zprobs)
 
-ZINB(n, mu, alpha, gamma)
+ZINB(n, mu, alpha, zprobs)
 }
 \arguments{
 \item{n}{the number of random draws, equal to number of species times the number of gradient locations.}
@@ -36,7 +36,9 @@ ZINB(n, mu, alpha, gamma)
 
 \item{theta}{numeric; a positive overdispersion parameter for the Beta-Binomial distribution.}
 
-\item{gamma}{numeric; zero-inflation parameter. Leads to the probability of a zero, \eqn{\pi}{pi}, in the binomial part of the ZIP via \eqn{\pi = e^\gamma / (1 + e^\gamma)}{pi = e^gamma / (1 + e^gamma)}. Setting \code{gamma = 0} gives a probability of zero from the binomial part of \eqn{\pi = 0.5}{pi = 0.5}.}
+\item{zprobs}{numeric; zero-inflation parameter giving the
+proportion of extraneous zeros. Must be in range
+\eqn{0 \dots 1}{0 to 1}.}
 }
 \value{
 a vector of random draws from the stated distribution.

--- a/man/distributions.Rd
+++ b/man/distributions.Rd
@@ -6,6 +6,8 @@
 \alias{Binomial}
 \alias{NegBin}
 \alias{Poisson}
+\alias{ZIB}
+\alias{ZIBB}
 \alias{ZINB}
 \alias{ZIP}
 \alias{distributions}
@@ -24,6 +26,10 @@ BetaBinomial(n, mu, size, theta)
 ZIP(n, mu, zprobs)
 
 ZINB(n, mu, alpha, zprobs)
+
+ZIB(n, mu, size, zprobs)
+
+ZIBB(n, mu, size, theta, zprobs)
 }
 \arguments{
 \item{n}{the number of random draws, equal to number of species times the number of gradient locations.}

--- a/man/distributions.Rd
+++ b/man/distributions.Rd
@@ -40,7 +40,10 @@ ZIBB(n, mu, size, theta, zprobs)
 
 \item{size}{numeric; binomial denominator, the total number of individuals counted for example}
 
-\item{theta}{numeric; a positive overdispersion parameter for the Beta-Binomial distribution.}
+\item{theta}{numeric; a positive inverse overdispersion parameter
+for the Beta-Binomial distribution. Low values give high
+overdispersion. The variance is
+\code{size*mu*(1-mu)*(1+(size-1)/(theta+1))} (Bolker, 2008)}
 
 \item{zprobs}{numeric; zero-inflation parameter giving the
 proportion of extraneous zeros. Must be in range
@@ -54,6 +57,10 @@ Wrappers to random number generators for use with coenocliner
 }
 \author{
 Gavin L. Simpson
+}
+\references{
+Bolker, B.M. (2008) \emph{Ecological Models and Data
+in R.} Princeton University Press.
 }
 \keyword{distribution}
 

--- a/tests/Examples/coenocliner-Ex.Rout.save
+++ b/tests/Examples/coenocliner-Ex.Rout.save
@@ -1,6 +1,6 @@
 
-R version 3.1.2 Patched (2014-12-02 r67096) -- "Pumpkin Helmet"
-Copyright (C) 2014 The R Foundation for Statistical Computing
+R Under development (unstable) (2015-02-17 r67835) -- "Unsuffered Consequences"
+Copyright (C) 2015 The R Foundation for Statistical Computing
 Platform: x86_64-unknown-linux-gnu (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
@@ -191,18 +191,18 @@ This is coenocliner 0.2-0
 +                 countModel = "poisson", expectation = TRUE)
 > plot(y, type = "l", lty = "solid")
 > 
-> ## Zero-inflated Poisson, constant gamma
-> ## =====================================
+> ## Zero-inflated Poisson, constant zero-inflation
+> ## ==============================================
 > 
 > y <- coenocline(x, responseModel = "beta", params = params,
-+                 countModel = "ZIP", countParams = list(gamma = 0))
++                 countModel = "ZIP", countParams = list(zprobs = 0.2))
 > plot(y, type = "l", lty = "solid")
 > 
-> ## Zero-inflated Negative binomial, constant gamma
+> ## Zero-inflated Negative binomial, constant zero-inflation
 > y <- coenocline(x, responseModel = "beta",
 +                 params = params,
 +                 countModel = "ZINB",
-+                 countParams = list(alpha = 0.75, gamma = 0))
++                 countParams = list(alpha = 0.75, zprobs = 0.2))
 > plot(y, type = "l", lty = "solid")
 > 
 > ## Binomial counts, constant size (m) of 100
@@ -467,7 +467,7 @@ Parameters:
 > ###
 > options(digits = 7L)
 > base::cat("Time elapsed: ", proc.time() - base::get("ptime", pos = 'CheckExEnv'),"\n")
-Time elapsed:  0.686 0.007 0.693 0 0 
+Time elapsed:  0.343 0.016 0.358 0 0 
 > grDevices::dev.off()
 null device 
           1 

--- a/vignettes/coenocliner.Rnw
+++ b/vignettes/coenocliner.Rnw
@@ -72,6 +72,8 @@ There's a long history of using computers to simulate species abundance data alo
   \item Beta-binomial
   \item Zero-inflated Poisson (ZIP)
   \item Zero-inflated negative binomial (ZINB)
+  \item Zero-inflated Binomial (ZIB)
+  \item Zero-inflated Beta-Binomial (ZIBB)
 \end{itemize}
 
 This vignette provides a brief overview of the \pkg{coenocliner} package.


### PR DESCRIPTION
This PR suggests the following changes:

1. The ZI-distributions are parametrized with argument `zprobs`  instead of `gamma == qlogis(zprobs)`.  This will change nothing because code already had the inverse function `plogis(gamma)`  that gives the `zprobs`, but the use of `zprobs`  is more transparent to normal users, and easier to explain what really happens: you add zeros at proportion `zprobs`. The `ZI*` functions were also internally simplified. Bolker (2008) uses `zprobs`. 

2. Two new functions are proposed: `ZIB` for zero-inflated Binomial, `ZIBB`  for zero-inflated Beta-Binomial.

3. The parametrization of overdispersion is explained for `BetaBinomial`

4. A reference was added to Bolker (2008).