### PR TITLE
Fix for testthat 3.3.0

### DIFF
--- a/tests/testthat/test-coenocline.R
+++ b/tests/testthat/test-coenocline.R
@@ -22,7 +22,7 @@ sim <- coenocline(x,
 test_that("coenocline() returns an integer matrix", {
     expect_that(sim, is_a("coenocline"))
     expect_that(sim, is_a("matrix"))
-    expect_that(typeof(sim) == "integer", is_true())
+    expect_true(typeof(sim) == "integer")
 })
 
 test_that("coenocline() returns matrix with correct number of species", {
@@ -52,7 +52,7 @@ sim <- coenocline(cbind(x, y),
 test_that("coenocline() returns an integer matrix with x and y gradients", {
     expect_that(sim, is_a("coenocline"))
     expect_that(sim, is_a("matrix"))
-    expect_that(typeof(sim) == "integer", is_true())
+    expect_true(typeof(sim) == "integer")
 })
 
 test_that("coenocline() returns matrix with correct number of species with x and y gradients", {


### PR DESCRIPTION
`is_true()`, `is_false()`, and `is_null()` have been removed (after several years of deprecation) because they conflict with functions defined elsewhere in the tidyverse. I've updated your code to use the modern equivalent(s).